### PR TITLE
Update documentation for unified images and zfs storage size support

### DIFF
--- a/docs/examples/gpu-ollama.md
+++ b/docs/examples/gpu-ollama.md
@@ -21,7 +21,7 @@ There a three differences to the other examples we've seen so far:
 
 1. `gpu_count: N` is added to the hostgroup, N is a the number of GPUs to allocate to each VM
 2. `hypervisor: cloud-hypervisor` - Cloud Hypervisor is used instead of Firecracker, to enable VFIO passthrough of a PCI device
-3. `image` / `kernel_image` - a separate Kernel and root filesystem is required for Cloud Hypervisor
+3. `image` - a separate Kernel and root filesystem is required for Cloud Hypervisor
 
 The following to `gpu.yaml`, make sure you update `vcpu` and `ram_gb`
 
@@ -42,7 +42,6 @@ config:
 
   github_user: alexellis
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel-ch:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd-ch:5.10.240-x86_64-latest"
 
   hypervisor: cloud-hypervisor
@@ -86,7 +85,7 @@ chmod +x ./setup-nvidia-run.sh
 sudo bash ./setup-nvidia-run.sh
 ```
 
-Compilation can take a minute or two, but can be sped up by caching all changed files and untaring them over the top of the root filesystem in [userdata](/tasks/userdata), or by [building a custom VM image](/tasks/custom-image) with the generated tar expanded. 
+Compilation can take a minute or two, but can be sped up by caching all changed files and untaring them over the top of the root filesystem in [userdata](/tasks/userdata), or by [building a custom VM image](/tasks/custom-image) with the generated tar expanded.
 
 If you run into an error, you can edit the script and uncomment the line `--no-unified-memory`.
 
@@ -95,9 +94,9 @@ Other commands to start a custom agent, or to install frameworks/tools can be ad
 Check the status of the driver with `nvidia-smi`:
 
 ```bash
-ubuntu@gpu-1:~$ nvidia-smi 
+ubuntu@gpu-1:~$ nvidia-smi
 
-Mon Sep  1 11:28:45 2025       
+Mon Sep  1 11:28:45 2025
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.76.05              Driver Version: 580.76.05      CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+
@@ -145,4 +144,3 @@ curl -SLs http://192.168.137.2:11434/api/generate -d '{
 ```
 
 Since we're using a persistent disk image, any models you download will be available if you restart or shutdown Slicer.
-

--- a/docs/examples/ha-k3s.md
+++ b/docs/examples/ha-k3s.md
@@ -29,10 +29,7 @@ config:
 
 # Comment out the image depending on your system's architecture
 
-  # kernel_image: "ghcr.io/openfaasltd/actuated-kernel:6.1.90-aarch64-latest"
   # image: "ghcr.io/openfaasltd/slicer-systemd-arm64:6.1.90-aarch64-latest"
-
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   hypervisor: firecracker
@@ -146,4 +143,3 @@ k3sup-pro apply
 Then edit your `~/.kube/config` file and replace `192.168.137.2:6443` with `192.168.1.100:6443`.
 
 Now every time you run `kubectl`, you'll see mixctl balance traffic across all three servers.
-

--- a/docs/examples/k3s-gpu.md
+++ b/docs/examples/k3s-gpu.md
@@ -23,7 +23,6 @@ config:
 
   github_user: alexellis
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel-ch:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd-ch:5.10.240-x86_64-latest"
 
   hypervisor: cloud-hypervisor
@@ -121,7 +120,7 @@ kubectl logs nvidia-smi
 
 ```bash
 $ kubectl logs pod/nvidia-smi
-Mon Sep  1 15:04:11 2025       
+Mon Sep  1 15:04:11 2025
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 580.76.05              Driver Version: 580.76.05      CUDA Version: 13.0     |
 +-----------------------------------------+------------------------+----------------------+

--- a/docs/examples/large-scale-k3s.md
+++ b/docs/examples/large-scale-k3s.md
@@ -60,11 +60,8 @@ config:
 
 # Comment out the image depending on your system's architecture
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:6.1.90-aarch64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd-arm64:6.1.90-aarch64-latest"
-
-# kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
-# image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
+  # image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   hypervisor: firecracker
 ```
@@ -145,5 +142,3 @@ kubectl top pod
 
 arkade install openfaas
 ```
-
-

--- a/docs/examples/multiple-machine-k3s.md
+++ b/docs/examples/multiple-machine-k3s.md
@@ -7,7 +7,7 @@ In this example, we'll show you spread Kubernetes clusters over multiple machine
 1. You want a multi-arch Kubernetes cluster - with Slicer on an x86_64 and Arm64 machine
 2. You want a much larger cluster than you can fit on any single machine
 
-The basic idea is that you run Slicer on two or more machines, which manages its own set of VMs. These are put on distinct subnets to avoid IP address conflicts, then a rule is added to the routing table to enable inter-connectivity. This isn't limited to just Kubernetes, you could run any network-based product or service you like across multiple machines with this technique. 
+The basic idea is that you run Slicer on two or more machines, which manages its own set of VMs. These are put on distinct subnets to avoid IP address conflicts, then a rule is added to the routing table to enable inter-connectivity. This isn't limited to just Kubernetes, you could run any network-based product or service you like across multiple machines with this technique.
 
 [![Adlink Ampere Developer Platform](/images/aadp.jpg)](/images/aadp.jpg)
 > If I need a very large Kubernetes cluster I'll often run the control-plane on an x86_64 Ryzen 9 7900X machine, and the worker nodes on an Arm64 Ampere Altra machine like the Adlink AADP pictured above. The machine above has 96 Arm cores and 196GB RAM.
@@ -46,7 +46,6 @@ config:
     port: 8080
     bind_address: "127.0.0.1:"
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   hypervisor: firecracker

--- a/docs/examples/openfaas.md
+++ b/docs/examples/openfaas.md
@@ -83,8 +83,7 @@ config:
       addresses:
       - 192.168.137.2/24
   github_user: alexellis
-  
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
+
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   api:
@@ -188,8 +187,7 @@ config:
       addresses:
       - 192.168.137.2/24
   github_user: alexellis
-  
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
+
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   api:

--- a/docs/examples/run-a-task.md
+++ b/docs/examples/run-a-task.md
@@ -40,7 +40,6 @@ config:
     bind_address: 127.0.0.1
     port: 8081
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   hypervisor: firecracker
@@ -195,4 +194,3 @@ Use it in your YAML file, replacing `kernel_image` with `kernel_file`:
   kernel_file: "./vmlinux"
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-2f2ebc0bbefe128aa3061e6ea6806cbcdc975208"
 ```
-

--- a/docs/getting-started/walkthrough.md
+++ b/docs/getting-started/walkthrough.md
@@ -26,7 +26,6 @@ config:
 
   github_user: alexellis
 
-  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
   image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
 
   hypervisor: firecracker
@@ -34,16 +33,14 @@ config:
 
 **Configuration for an Arm64 Slicer installation**
 
-If you're deploying to an Arm64 host, then the only changes needed to the `vm.yaml` file are to the `kernel_image` and `image` fields:
+If you're deploying to an Arm64 host, then the only changes needed is to select a different `image` in the `vm.yaml` file:
 
 ```diff
--  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:5.10.240-x86_64-latest"
 -  image: "ghcr.io/openfaasltd/slicer-systemd:5.10.240-x86_64-latest"
-+  kernel_image: "ghcr.io/openfaasltd/actuated-kernel:6.1.90-aarch64-latest"
 +  image: "ghcr.io/openfaasltd/slicer-systemd-arm64:6.1.90-aarch64-latest"
 ```
 
-The `storage: image` setting means a disk image will be cloned from the root filesystem into a local file. It's not the fastest option for the initial setup, but it's the simplest, persistent and great for long-living VMs. 
+The `storage: image` setting means a disk image will be cloned from the root filesystem into a local file. It's not the fastest option for the initial setup, but it's the simplest, persistent and great for long-living VMs.
 
 Now, open a new terminal window, or ideally launch `tmux` so you can leave the binary running in the background.
 
@@ -98,7 +95,7 @@ $ sudo tail -f /var/log/slicer/vm-1.txt
 
 Ubuntu 22.04.5 LTS vm-1 ttyS0
 
-vm-1 login: 
+vm-1 login:
 ```
 
 If you want to tail the logs from all available VMs at once, use `fstail` via `arkade get fstail`:
@@ -150,4 +147,3 @@ Example:
 ```bash
 ssh -p 2222 ubuntu@localhost
 ```
-

--- a/docs/storage/zfs.md
+++ b/docs/storage/zfs.md
@@ -19,9 +19,9 @@ config:
 +   storage: zfs
 ```
 
-Bear in mind that with this initial version of ZFS storage, the VM size will have to match whatever is configured for the zvol snapshotter.
+If `storage_size` is not set in the host group configuration the size of the storage volume is set to whatever is configured for the zvol snapshotter. It is possible to request a custom size by setting `storage_size`. Bear in mind that zvol snapshotter can only increase the snapshot size for a VM. This means the `storage_size` has to be the same or bigger than the default size configured for the zvol snapshotter (the default size is `20G`).
 
-So if the default is not large enough for your needs, delete the snapshot, then adjust the configuration and restart the snapshotter.
+So if the default is too large for your needs, delete the snapshot, then adjust the configuration and restart the snapshotter.
 
 ## Install packages for ZFS
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Remove references to kernel_image

    Images for slicer have been unified and now contain the kernel embedded
    in the rootfs images. The kernel_image field is not required anymore.

- Add note on storage_size for zfs storage

    Document support for setting storage_size when using zfs storage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the docs site renders correctly after these updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
