### PR TITLE
Add instructions for running slicer with PVM

### DIFF
--- a/docs/examples/openfaas-edge.md
+++ b/docs/examples/openfaas-edge.md
@@ -10,14 +10,17 @@ Create `openfaas-edge.sh`.
 
 By default the script installs OpenFaaS Edge a private registry and the [OpenFaaS Function Builder API](https://docs.openfaas.com/edge/builder/) as additional services. Select which services to install by changing the environment variables in the script configuration section.
 
-Note that the function builder addon requires a separate license.
-
 Available configuration options:
 
 | Env | Description | Default|
 | --- | ----------- | ------ |
 | INSTALL_REGISTRY | Install a private registry | `true` |
 | INSTALL_BUILDER | Install the OpenFaaS Function Builder API | `true` |
+
+!!! note "OpenfaaS Edge license"
+
+    Slicer subcriptions or GitHub sponsorship does not include the function builder addon for OpenFaaS Edge.
+    A separate [OpenFaaS Edge license](https://www.openfaas.com/pricing/) is required to use the function builder.
 
 ```bash
 #!/usr/bin/env bash

--- a/docs/tasks/execute-commands-with-sdk.md
+++ b/docs/tasks/execute-commands-with-sdk.md
@@ -78,8 +78,8 @@ func run() error {
 
 	// Define VM specifications
 	createReq := sdk.SlicerCreateNodeRequest{
-		RamGB:    8, // 8GB RAM
-		CPUs:     4, // 4 CPU cores for video processing
+		RamBytes:    8 * 1024 * 1024 * 1024, // 8GB RAM
+		CPUs:        4, // 4 CPU cores for video processing
 	}
 
 	// Create VM in the 'sdk' host group

--- a/docs/tasks/pvm.md
+++ b/docs/tasks/pvm.md
@@ -1,0 +1,118 @@
+# Run slicer without KVM on cloud VMs
+
+PVM (Pagetable Virtual Machine) enables Slicer microVMs to run on cloud VMs without nested virtualization enabled or missing the `/dev/kvm` device.
+
+This is particularly useful for AWS EC2 instances, where bare-metal options are significantly more expensive than regular VMs, or other cloud providers where nested virtualization isn't available.
+
+!!! note "Architecture Support"
+    PVM currently supports x86_64 architecture only. Arm64 support is not available.
+
+Running Slicer with PVM requires a custom kernel on the host and compatible guest images. Additionally, a patched Firecracker version is require to support PVM.
+
+## Install PVM kernel on the host
+
+Create a new VM instance on your cloud and select Ubuntu 24.04 as the operating system.
+
+> PVM has been tested on Ubuntu 24.04 on [Amazon EC2](https://aws.amazon.com/ec2) and [Hetzner Cloud](https://www.hetzner.com/cloud).
+
+SSH into the host and install the pre-built PVM kernel packages.
+
+Install arkade if it is not on your system already:
+
+```bash
+curl -sLS https://get.arkade.dev | sudo sh
+```
+
+Download the kernel packages:
+
+```bash
+arkade oci install ghcr.io/openfaasltd/actuated-kernel-pvm-host:x86_64-latest \
+  --path .
+```
+
+Install the downloaded packages:
+
+```bash
+sudo dpkg -i *.deb
+```
+
+Configure the kernel boot parameters. PVM requires Page Table Isolation (PTI) to be disabled:
+
+```bash
+# Configure GRUB to append pti=off to existing kernel parameters
+sudo sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/ { s/pti=off//g; s/"$/ pti=off"/; s/  */ /g }' /etc/default/grub
+sudo sed -i '/^GRUB_CMDLINE_LINUX=/ { s/pti=off//g; s/"$/ pti=off"/; s/  */ /g }' /etc/default/grub
+```
+
+Configure GRUB to use the new kernel:
+
+```bash
+# Enable an override to the saved default
+sudo sed -i 's/^GRUB_DEFAULT=.*/GRUB_DEFAULT=saved/' /etc/default/grub
+sudo update-grub
+
+# View available kernel options
+sudo grep -n "menuentry '" /boot/grub/grub.cfg | sed "s/.*menuentry '\(.*\)'.*/\1/"
+
+# Set the new PVM kernel as default
+sudo grub-set-default "Advanced options for Ubuntu>Ubuntu, with Linux 6.12.33"
+sudo update-grub
+
+# Update all initramfs images
+sudo update-initramfs -u -k all
+```
+
+Reboot the system to boot into the PVM kernel:
+
+```bash
+sudo reboot
+```
+
+After reboot, verify the new kernel is running and load the PVM module:
+
+```bash
+# Verify PVM kernel is active
+uname -a
+
+# Load the PVM kernel module
+sudo modprobe kvm_pvm
+```
+
+You can also use `lsmod` to verify the kvm_pvm module is loaded:
+
+```sh
+Module                  Size  Used by
+kvm_pvm                53248  0
+kvm                  1400832  1 kvm_pvm
+```
+
+## Install Slicer
+
+Follow the standard [installation instructions for slicer](/getting-started/install/). The installation script automatically downloads a forked Firecracker binary with PVM support.
+
+When creating VMs on a PVM-enabled host, use the PVM-compatible base image.
+
+Update the `image` field in slicer config files:
+
+```yaml
+  image: "ghcr.io/openfaasltd/slicer-systemd-2204-pvm:x86_64-latest"
+```
+
+Note that at the moment PVM is only supported when using Firecracker as the hypervisor.
+
+Ensure the correct hypervisor is selected in slicer config files:
+
+```yaml
+  hypervisor: "firecracker"
+```
+
+## Performance considerations
+
+PVM adds virtualization overhead compared to bare-metal KVM. Based on testing:
+
+- I/O intensive workloads may see significant performance impact
+- CPU-bound tasks typically see lower overhead
+- Long-running services and HTTP workloads are less affected
+- Cold start times remain fast
+
+For optimal performance, consider bare-metal hosts with hardware virtualization when possible. PVM is ideal when bare-metal isn't available or cost-effective.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
       - Logs & Monitoring: tasks/monitoring.md
       - Share files over NFS: tasks/share-files-with-nfs.md
       - Nested Virtualization: tasks/nested-virtualization.md
+      - Run slicer without KVM on cloud VMs: tasks/pvm.md
       - Execute commands in VMs with the SDK: tasks/execute-commands-with-sdk.md
   - Storage:
       - Overview: storage/overview.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a docs page to show users how to install and run slicer microVMs with PVM on hosts without KVM support.

Additional changes:

- Update the note for OpenFaaS Edge licenses for the function builder.
- Update Slicer SDK examples for latest SDK release.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

Show users how to run Slicer on clouds without support for nested virtualization.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Followed the instructions to setup a PVM host to verify all provided commands are working.
Ran the docs site locally:
 - Verified the new page renders correctly.
 - Verified links are working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
