### PR TITLE
Add docs page for exec and cp VM operations

### DIFF
--- a/docs/examples/autoscaling-k3s.md
+++ b/docs/examples/autoscaling-k3s.md
@@ -635,7 +635,7 @@ Look out to see if you've exceeded the maximum number of nodes for a node group 
 
 **Diagnose an issue within a worker node**
 
-The `slicer vm exec` command will give you a root shell directly into any worker node.
+The `slicer vm shell` command will give you a root shell directly into any worker node.
 
 On the host managing `k3s-agents-1`, you would run:
 

--- a/docs/examples/jenkins.md
+++ b/docs/examples/jenkins.md
@@ -177,7 +177,7 @@ sudo -E slicer up ./jenkins-master.yaml
 You can run an interactive shell into the VM and read the password file directly from `/home/ubuntu/jenkins-admin.txt`:
 
 ```bash
-$ sudo -E ./bin/slicer vm exec jenkins-master-1
+$ sudo -E ./bin/slicer vm shell jenkins-master-1
 
 Connecting to VM: jenkins-master-1
 Connected! Press Ctrl+] to exit.
@@ -446,7 +446,7 @@ Find out whether there are networking or other issues with the following
 * Check the logs of the jenkins server on the master
 
 ```bash
-sudo -E slicer vm exec jenkins-master-1
+sudo -E slicer vm shell jenkins-master-1
 sudo journalctl -u jenkins.service -f
 ```
 

--- a/docs/examples/run-a-task.md
+++ b/docs/examples/run-a-task.md
@@ -138,9 +138,9 @@ RUN systemctl disable regen-ssh-host-keys &&
     systemctl disable slicer-vmmeter
 ```
 
-After SSH is disabled, the only way to debug a machine is via the Slicer agent using `slicer vm exec` to get a shell.
+After SSH is disabled, the only way to debug a machine is via the Slicer agent using `slicer vm shell` to get a shell.
 
-You can also disable `slicer-ssh-agent` (not actually a full SSH daemon), however the `slicer vm` commands will no longer work.
+You can also disable `slicer-agent` (not actually a full SSH daemon), however the `slicer vm` commands will no longer work.
 
 If you publish an image to the Docker Hub, make sure you include its prefix i.e. `docker.io/owner/repo:tag`.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -206,9 +206,62 @@ HTTP GET
 
 HTTP GET
 
-This is an internal endpoint used by `slicer vm exec` to obtain a shell. It requires the `slicer-ssh-agent` service to be running within the guest microVM.
+This is an internal endpoint used by `slicer vm shell` to obtain a shell. It requires the `slicer-agent` service to be running within the guest microVM.
+
+`/vm/{hostname}/shell`
+
+## Copy files
+
+HTTP POST/GET
+
+`/vm/{hostname}/cp`
+
+Copy files to/from a VM. Requires the `slicer-agent` service running in the guest VM and `tar` utility available.
+
+**Copy to VM (POST):**
+- Content-Type: `application/x-tar`
+- Body: tar stream of files to copy
+- Query parameters:
+  - `path` (required): destination path in VM
+  - `uid` (optional): user ID for file ownership
+  - `gid` (optional): group ID for file ownership
+
+**Copy from VM (GET):**
+- Query parameters:
+  - `path` (required): source path in VM
+- Response: tar stream of requested files
+
+## Execute commands
+
+HTTP POST
 
 `/vm/{hostname}/exec`
+
+Execute commands on a VM. Requires the `slicer-agent` service running in the guest VM.
+
+Query parameters:
+- `cmd` (required): command to execute
+- `args` (optional, multiple): command arguments
+- `uid` (optional): user ID to run command as (default: 0)
+- `gid` (optional): group ID to run command as (default: 0)
+- `cwd` (optional): working directory
+- `shell` (optional): shell interpreter (default: /bin/bash)
+- `stdin` (optional): enable stdin pipe (true/false)
+- `permissions` (optional): file permissions for output
+
+Body: stdin data (if `stdin=true`)
+
+Response: streaming newline-delimited JSON with stdout/stderr/exit_code
+
+Example response stream:
+
+```json
+{"stdout":"Hello from VM\n","stderr":"","exit_code":0}
+{"stdout":"","stderr":"some error\n","exit_code":0}
+{"stdout":"","stderr":"","exit_code":0}
+```
+
+Each JSON object is separated by a newline character.
 
 ## Manage secrets
 

--- a/docs/reference/vm-operations.md
+++ b/docs/reference/vm-operations.md
@@ -1,0 +1,90 @@
+# VM Operations: Copy and Exec
+
+Slicer provides commands to interact with running VMs through the `slicer vm cp` (copy) and `slicer vm exec` (execute) commands.
+
+- Slicer copy allows users to copy a file or folder from the local machine into the vm or vica versa.
+- Slicer exec runs a command as a given user or root in the microVM
+
+
+## Copy files from host to VM
+
+The copy command enables bidirectional file transfer between the host and guest VMs without the need of mounting any folders to VMs.
+
+For example, to copy a file named `local-file.txt` from the host to a VM named `vm-1` use the command:
+
+```bash
+slicer vm cp example.txt vm-1:.
+```
+
+To copy a file from the instance named `vm-1` run:
+
+```bash
+slicer vm cp vm-1:/home/ubuntu/example.txt .
+```
+
+It is also possible to copy an entire directory between host and a VM:
+
+```bash
+# Copy a directory from local machine to VM
+slicer vm cp /etc vm-1:/tmp/etc
+
+# Copy a directory from VM to local machine
+slicer vm cp vm-1:/etc /tmp/etc
+```
+
+Slicer supports two copy modes. The default tar mode supports directories and preserves file structure using compression for efficient transfer. Binary mode provides file-by-file transfer and supports custom permissions setting, making it ideal for single files with specific permission requirements:
+
+```bash
+# Use tar mode explicitly (default)
+slicer vm cp --mode tar vm-1:/home/ubuntu/documents ./documents
+
+# Use binary mode with custom permissions
+slicer vm cp --mode binary --permissions 0755 ./script.sh vm-1:/usr/local/bin/script.sh
+```
+
+## Execute commands
+
+The exec command allows you to run commands remotely on VMs. The first argument is the instance to run the commands on, `--` optionally separates the slicer CLI options from the command to run on the VM.
+
+```bash
+# Run a command as root (default)
+slicer vm exec vm-1 whoami
+```
+
+Slicer allows you to control the command execution context, including user permissions and working directory.
+
+```bash
+# Run command as non-root user (UID 1000)
+slicer vm exec vm-1 --uid 1000 whoami
+```
+
+Change the working directory and run commands with arguments:
+
+```bash
+# Execute command in specific directory
+slicer vm exec vm-1 --cwd /var/log -- ls -la
+```
+
+Control shell interpretation for complex commands:
+
+```bash
+# Use default bash shell for complex commands with pipes
+slicer vm exec vm-1 -- "ls -l | sort"
+
+# Use custom shell interpreter
+slicer vm exec vm-1 --shell /bin/zsh -- "echo $SHELL"
+
+# Execute directly without shell (faster for simple commands)
+slicer vm exec vm-1 --shell "" whoami
+```
+
+Combine with local commands using pipes and STDIO:
+
+```bash
+# Pipe local file content to VM command
+cat /etc/hostname | slicer vm exec vm-1 -- base64 --wrap 9999
+```
+
+## Guest VM Requirements
+
+Both commands require the `slicer-agent` daemon running within the guest VM. For copy operations, the `tar` utility must be available in the VM's `$PATH`. These requirements are included by default in the various supported Slicer VM images.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - Serial Over SSH (SOS): reference/sos.md
       - VFIO Passthrough: reference/vfio.md
       - Troubleshooting: reference/troubleshooting.md
+      - VM Operations: reference/vm-operations.md
 # extra:
 #   analytics:
 #     provider: google


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add reference and API documentation for the new slicer  exec and cp functionality.

Update references to the old `slicer vm exec` command that was renamed to `slicer vm shell`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

Document latest slicer feature additions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified all commands.
Verified the docs site renders correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
