### PR TITLE
Fix length of host group name in of-edge example

### DIFF
--- a/docs/examples/openfaas-edge.md
+++ b/docs/examples/openfaas-edge.md
@@ -305,7 +305,7 @@ fi
 Use `slicer new` to generate a configuration file:
 
 ```bash
-slicer new openfaas-edge \
+slicer new of-edge \
   --userdata-file ./openfaas-edge.sh \
   > openfaas-edge.yaml
 ```
@@ -321,7 +321,7 @@ The userdate script provided in this guide can be used with both Ubuntu and Rock
 Start the VM:
 
 ```sh
-sudo -E slicer up ./openfaas-edge.yaml`
+sudo -E slicer up ./openfaas-edge.yaml
 ```
 
 Login to the VM and activate faasd using a static license key are by running faasd activate.
@@ -329,7 +329,7 @@ Login to the VM and activate faasd using a static license key are by running faa
 Commercial users can create their license key as follows:
 
 ```sh
-sudo nano /var/lib/faasd/secrets/openfaas_license"
+sudo nano /var/lib/faasd/secrets/openfaas_license
 ```
 
 For personal, non-commercial use only, GitHub Sponsors of @openfaas can run:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The long host group named resulted in bridge name that was to long and caused slicer up to fail with the error:

```
Unable to setup bridge: bropenfaas-edge0, error: numerical result out of range
numerical result out of range
```

PR includes some other small fixes for example commands

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

Ensure all commands work and can be copy pasted without modification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the updated commands to verify they are correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
