### PR TITLE
Fix YAML Config nav link to point to correct file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,7 @@ nav:
           - Devmapper: storage/devmapper.md
       - Reference:
           - REST API: reference/api.md
-          - YAML Config: reference/yaml.md
+          - YAML Config: reference/config.md
           - Images for microVMs: reference/images.md
           - SSH access to VMs: reference/ssh.md
           - Secret management: reference/secrets.md


### PR DESCRIPTION
## Description
The nav entry for "YAML Config" in `mkdocs.yml` pointed to `reference/yaml.md`, but the actual file is `reference/config.md`. This caused a 404 at `docs.slicervm.com/reference/yaml.md`.

Verified that no blog posts or docs pages link to this URL, so the change is safe.

## Motivation and Context
Fixing a broken link in the docs navigation that results in a 404.

- [ ] I have raised an issue to propose this change

## How Has This Been Tested?
Ran the site locally and verified the YAML reference page is available.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`