### PR TITLE
Document suspend-on-shutdown behavior

### DIFF
--- a/docs/getting-started/daemon.md
+++ b/docs/getting-started/daemon.md
@@ -113,7 +113,7 @@ This is useful for planned host maintenance, such as upgrading the host
 kernel and rebooting without losing in-memory VM state, long-running shell
 sessions, or background processes inside the VM.
 
-To enable it on an existing service, update the `ExecStart` line and make
+To enable it add the `--suspend-on-shutdown` to `ExecStart` and make
 sure the stop timeout gives Slicer enough time to suspend the VMs:
 
 ```diff

--- a/docs/getting-started/daemon.md
+++ b/docs/getting-started/daemon.md
@@ -101,3 +101,27 @@ sudo journalctl --output=cat --since yesterday -u vm
 To stop the service run `sudo systemctl stop vm`, and to prevent it loading on start-up run: `sudo systemctl disable vm`.
 
 You can create multiple Slicer services to run different sets of VMs or configurations on the same host.
+
+## Preserve VM state across host reboots
+
+If you use the Firecracker hypervisor, you can add `--suspend-on-shutdown`
+to `slicer up` so that Slicer suspends running VMs to disk when the daemon
+is stopped. On the next daemon start, Slicer automatically restores the VMs
+that were suspended by the shutdown path.
+
+This is useful for planned host maintenance, such as upgrading the host
+kernel and rebooting without losing in-memory VM state, long-running shell
+sessions, or background processes inside the VM.
+
+To enable it on an existing service, update the `ExecStart` line and make
+sure the stop timeout gives Slicer enough time to suspend the VMs:
+
+```diff
+- ExecStart=sudo /usr/local/bin/slicer up ./slicer.yaml
++ ExecStart=sudo /usr/local/bin/slicer up ./slicer.yaml --suspend-on-shutdown
+- TimeoutStopSec=30
++ TimeoutStopSec=120
+```
+
+If suspend fails, Slicer falls back to its normal graceful or forceful
+shutdown behavior.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -918,12 +918,12 @@ paths:
 
   /vm/{hostname}/suspend:
     post:
-      summary: Suspend a VM to disk (Slicer-for-Mac only, for now)
+      summary: Suspend a VM to disk
       description: |
         Takes a Firecracker snapshot of the VM's memory and disk state, then
         shuts down the underlying VM process. Memory is released. Pair with
-        `/restore` to bring the VM back up. Currently supported on
-        Slicer-for-Mac only.
+        `/restore` to bring the VM back up. Supported on Slicer-for-Mac,
+        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
       security:
         - BearerAuth: []
       parameters:
@@ -955,11 +955,11 @@ paths:
 
   /vm/{hostname}/restore:
     post:
-      summary: Restore a VM from its snapshot (Slicer-for-Mac only, for now)
+      summary: Restore a VM from its snapshot
       description: |
         Restores a previously-suspended VM from its Firecracker snapshot.
-        Memory and disk state come back intact. Currently supported on
-        Slicer-for-Mac only.
+        Memory and disk state come back intact. Supported on Slicer-for-Mac,
+        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
       security:
         - BearerAuth: []
       parameters:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -609,7 +609,7 @@ HTTP POST
 
 Response 200: text/plain
 
-## Suspend a VM to disk (Slicer-for-Mac only, for now)
+## Suspend a VM to disk
 
 HTTP POST
 
@@ -619,12 +619,12 @@ Takes a Firecracker snapshot of the VM's memory and disk state, then
 shuts down the underlying VM process. Memory is released. Use
 `/restore` to bring the VM back up from the snapshot.
 
-> Availability: currently supported on Slicer-for-Mac only. Not
-> available on the Linux daemon yet.
+> Availability: supported on Slicer-for-Mac, and on Linux when the Slicer
+> daemon is using the Firecracker hypervisor.
 
 Response 200: text/plain
 
-## Restore a VM from a snapshot (Slicer-for-Mac only, for now)
+## Restore a VM from a snapshot
 
 HTTP POST
 
@@ -633,8 +633,8 @@ HTTP POST
 Restores a previously-suspended VM from its Firecracker snapshot. The
 VM resumes with its memory and disk state intact.
 
-> Availability: currently supported on Slicer-for-Mac only. Not
-> available on the Linux daemon yet.
+> Availability: supported on Slicer-for-Mac, and on Linux when the Slicer
+> daemon is using the Firecracker hypervisor.
 
 Response 200: text/plain
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -125,3 +125,8 @@ See the [API reference](/reference/api) for endpoint documentation.
 | `hypervisor` | string | `firecracker` | `firecracker` or `cloud-hypervisor` |
 | `graceful_shutdown` | bool | `true` | Send ACPI shutdown before killing VMs |
 | `pci` | map | | PCI device passthrough. See [VFIO docs](/reference/vfio) |
+
+When running Slicer as a daemon with Firecracker, you can also pass
+`--suspend-on-shutdown` to `slicer up` to suspend running VMs when the daemon
+stops and automatically restore them on the next daemon start. See [Preserve
+VM state across host reboots](/getting-started/daemon/#preserve-vm-state-across-host-reboots).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1232,12 +1232,12 @@ paths:
 
   /vm/{hostname}/suspend:
     post:
-      summary: Suspend a VM to disk (Slicer-for-Mac only, for now)
+      summary: Suspend a VM to disk
       description: |
         Takes a Firecracker snapshot of the VM's memory and disk state, then
         shuts down the underlying VM process. Memory is released. Pair with
-        `/restore` to bring the VM back up. Currently supported on
-        Slicer-for-Mac only.
+        `/restore` to bring the VM back up. Supported on Slicer-for-Mac,
+        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
       security:
         - BearerAuth: []
       parameters:
@@ -1269,11 +1269,11 @@ paths:
 
   /vm/{hostname}/restore:
     post:
-      summary: Restore a VM from its snapshot (Slicer-for-Mac only, for now)
+      summary: Restore a VM from its snapshot
       description: |
         Restores a previously-suspended VM from its Firecracker snapshot.
-        Memory and disk state come back intact. Currently supported on
-        Slicer-for-Mac only.
+        Memory and disk state come back intact. Supported on Slicer-for-Mac,
+        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
       security:
         - BearerAuth: []
       parameters:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds documentation for the `--suspend-on-shutdown` option.

The daemon guide now explains how to preserve VM state across host reboots . The API reference also clarifies where suspend and restore are available, and the config reference links to the daemon guidance near the existing shutdown behavior settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

This helps users find the suspend-on-shutdown behavior when configuring Slicer as a long-running daemon, especially for planned host maintenance such as kernel upgrades and reboots.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reviewed the Markdown changes locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
