### PR TITLE
Update daemon docs for service command

### DIFF
--- a/docs/getting-started/daemon.md
+++ b/docs/getting-started/daemon.md
@@ -11,6 +11,8 @@ Not only can we monitor Slicer's logs via `journalctl`, but we can manage it wit
 
 You can run one or many Slicer daemons in this way, just make sure the host group CIDRs do not overlap, and that the API binds to a different UNIX socket or a different TCP port.
 
+## Install Slicer as a systemd service
+
 Let's say you wanted to create a service for a hostgroup named "vm":
 
 ```bash
@@ -21,28 +23,30 @@ slicer new vm > ./slicer.yaml
 
 To listen on a UNIX port instead, use `slicer new vm --api-auth=false --api-bind ./slicer.sock > ./slicer.yaml`.
 
-Create a service named i.e. `vm.service`:
+Install and start the service:
 
 ```bash
-[Unit]
-Description=Slicer for vm
-
-[Service]
-User=alex
-Type=simple
-WorkingDirectory=/home/alex/vm
-ExecStart=sudo /usr/local/bin/slicer up ./slicer.yaml
-Environment=SUDO_USER=alex
-Restart=always
-RestartSec=30s
-KillMode=mixed
-TimeoutStopSec=30
-
-[Install]
-WantedBy=multi-user.target
+sudo slicer service generate --install \
+  --name slicer \
+  ./slicer.yaml
 ```
 
-Next, make sure the target user i.e. `alex` has password-less sudo permissions to run `slicer`:
+The `--install` flag creates `/etc/systemd/system/slicer.service`, enables it, and starts it. It will not overwrite an existing unit unless you pass `--force`.
+
+By default, the generated unit runs Slicer as `root` and uses the current directory as its working directory unless you pass `--working-directory`.
+
+The license file defaults to the invoking user's `~/.slicer/LICENSE`. If you pass `--user`, Slicer resolves that user's license instead. Pass `--license-file` to use a specific path.
+
+If you need the service process to run as another user, pass `--user`:
+
+```bash
+sudo slicer service generate --install \
+  --name slicer \
+  --user alex \
+  ./slicer.yaml
+```
+
+When using a non-root service user, the generated unit runs Slicer through `sudo`, so make sure the user has passwordless sudo permission to run Slicer.
 
 Run `visudo`, then add this line to the end of the file, replacing `alex` with your username:
 
@@ -52,18 +56,10 @@ alex ALL=(ALL) NOPASSWD: ALL
 
 Or you could be more specific and only allow `slicer` to elevate to sudo for your user:
 
-```
+```bash
 export USER=alex
 
 echo "$USER ALL=(ALL) NOPASSWD: /usr/local/bin/slicer" | sudo tee /etc/sudoers.d/$USER-slicer
-```
-
-Install the service, and set it to start up on reboots:
-
-```bash
-sudo cp ./vm.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now vm.service
 ```
 
 Assuming you went for the UNIX socket option, you could run i.e.
@@ -88,40 +84,54 @@ To view the logs for the service run:
 
 ```bash
 # Page through all logs
-sudo journalctl -f --output=cat -u vm
+sudo journalctl -f --output=cat -u slicer
 
 # Page through all logs
-sudo journalctl --output=cat -u vm
+sudo journalctl --output=cat -u slicer
 
 # View all logs since today/yesterday
-sudo journalctl --output=cat --since today -u vm
-sudo journalctl --output=cat --since yesterday -u vm
+sudo journalctl --output=cat --since today -u slicer
+sudo journalctl --output=cat --since yesterday -u slicer
 ```
 
-To stop the service run `sudo systemctl stop vm`, and to prevent it loading on start-up run: `sudo systemctl disable vm`.
+To stop the service run `sudo systemctl stop slicer`, and to prevent it loading on start-up run: `sudo systemctl disable slicer`.
 
 You can create multiple Slicer services to run different sets of VMs or configurations on the same host.
 
 ## Preserve VM state across host reboots
 
-If you use the Firecracker hypervisor, you can add `--suspend-on-shutdown`
-to `slicer up` so that Slicer suspends running VMs to disk when the daemon
-is stopped. On the next daemon start, Slicer automatically restores the VMs
-that were suspended by the shutdown path.
+If you use the Firecracker hypervisor, you can add `--suspend-on-shutdown` to `slicer service generate` so that Slicer suspends running VMs to disk when the daemon is stopped. On the next daemon start, Slicer automatically restores the VMs that were suspended by the shutdown path.
 
-This is useful for planned host maintenance, such as upgrading the host
-kernel and rebooting without losing in-memory VM state, long-running shell
-sessions, or background processes inside the VM.
+This is useful for planned host maintenance, such as upgrading the host kernel and rebooting without losing in-memory VM state, long-running shell sessions, or background processes inside the VM.
 
-To enable it add the `--suspend-on-shutdown` to `ExecStart` and make
-sure the stop timeout gives Slicer enough time to suspend the VMs:
+To enable it, pass `--suspend-on-shutdown` when installing the service:
 
-```diff
-- ExecStart=sudo /usr/local/bin/slicer up ./slicer.yaml
-+ ExecStart=sudo /usr/local/bin/slicer up ./slicer.yaml --suspend-on-shutdown
-- TimeoutStopSec=30
-+ TimeoutStopSec=120
+```bash
+sudo slicer service generate --install \
+  --name slicer \
+  --suspend-on-shutdown \
+  ./slicer.yaml
 ```
 
-If suspend fails, Slicer falls back to its normal graceful or forceful
-shutdown behavior.
+The generated unit defaults `TimeoutStopSec` to `120` seconds. Increase it with `--timeout-stop-sec` if your VMs need more time to suspend.
+
+If suspend fails, Slicer falls back to its normal graceful or forceful shutdown behavior.
+
+## Generate a systemd unit
+
+You can also generate the systemd unit without installing it. This is useful if you want to pipe it into another command, save it to a file, or inspect it before installing:
+
+```bash
+slicer service generate \
+  --name slicer \
+  ./slicer.yaml
+```
+
+To generate a unit for a non-root service user:
+
+```bash
+slicer service generate \
+  --name slicer \
+  --user alex \
+  ./slicer.yaml
+```


### PR DESCRIPTION
## Description

Updates the daemon guide to use `slicer service generate --install` as the default way to create, enable, and start a systemd service.

Also documents generating a unit without installing it, updates the suspend-on-shutdown example to use the service command.

## Motivation and Context

The Slicer CLI now includes service commands for generating and installing systemd units, so the docs no longer need to show a hand-written unit file and manual `systemctl` setup.

- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Verified the commands shown in the updated guide and checked that the markdown renders correctly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`