### PR TITLE
Document cold forking workflows

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -209,10 +209,8 @@ components:
 
     SlicerCreateNodeRequest:
       type: object
-      description: Combined from LaunchParams and SDK request.
+      description: Public parameters for allocator-led VM creation.
       properties:
-        hostname:
-          type: string
         ip:
           type: string
         ram_bytes:
@@ -232,8 +230,6 @@ components:
           type: array
           items:
             type: string
-        protected:
-          type: boolean
         userdata:
           type: string
         tags:
@@ -248,6 +244,8 @@ components:
           type: array
           items:
             type: string
+        network:
+          $ref: '#/components/schemas/SlicerForkNetworkPolicy'
 
     SlicerCreateNodeResponse:
       type: object
@@ -263,6 +261,131 @@ components:
           format: date-time
         arch:
           type: string
+
+    SlicerResolvedNetworkPolicy:
+      type: object
+      required: [allow, drop]
+      properties:
+        allow:
+          type: array
+          items: { type: string }
+        drop:
+          type: array
+          items: { type: string }
+
+    SlicerVMNetworkDescription:
+      type: object
+      required: [host_group, effective]
+      properties:
+        mode: { type: string }
+        policy_source:
+          type: string
+          enum: [host_group, mixed, vm]
+        host_group:
+          $ref: '#/components/schemas/SlicerResolvedNetworkPolicy'
+        override:
+          $ref: '#/components/schemas/SlicerForkNetworkPolicy'
+        effective:
+          $ref: '#/components/schemas/SlicerResolvedNetworkPolicy'
+
+    SlicerVMDescription:
+      allOf:
+        - $ref: '#/components/schemas/NodeResponse'
+        - type: object
+          required: [network]
+          properties:
+            storage: { type: string }
+            image: { type: string }
+            commit_id: { type: string }
+            parent_commit_id: { type: string }
+            network:
+              $ref: '#/components/schemas/SlicerVMNetworkDescription'
+
+    SlicerCommitRequest:
+      type: object
+      properties:
+        tags:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        cache_key:
+          type: string
+          description: Caller-owned unique key used to find or reuse a commit.
+
+    SlicerCommitResponse:
+      type: object
+      properties:
+        hostname: { type: string }
+        commit_id: { type: string }
+        status: { type: string, enum: [committed] }
+        parent_status: { type: string, enum: [stopped] }
+        mode: { type: string, enum: [disk] }
+        tags:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        cache_key: { type: string }
+      required: [hostname, commit_id, status, parent_status, mode]
+
+    SlicerCommitInfo:
+      type: object
+      properties:
+        commit_id: { type: string }
+        source_hostname: { type: string }
+        source_host_group: { type: string }
+        created_at: { type: string, format: date-time }
+        mode: { type: string, enum: [disk] }
+        tags:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        cache_key: { type: string }
+      required: [commit_id, source_hostname, source_host_group, created_at, mode]
+
+    SlicerForkNetworkPolicy:
+      type: object
+      description: Isolated-network overrides for the child VM.
+      properties:
+        allow:
+          type: array
+          items: { type: string }
+        drop:
+          type: array
+          items: { type: string }
+
+    SlicerForkRequest:
+      type: object
+      properties:
+        tags:
+          type: array
+          items: { type: string }
+        network:
+          $ref: '#/components/schemas/SlicerForkNetworkPolicy'
+
+    SlicerForkResponse:
+      type: object
+      properties:
+        hostname: { type: string, description: Allocated hostname of the forked VM. }
+        source_hostname: { type: string, description: Source VM hostname. }
+        commit_id: { type: string }
+        status: { type: string, enum: [forked] }
+        parent_status: { type: string, enum: [unchanged] }
+        child_status: { type: string, enum: [running] }
+        mode: { type: string, enum: [disk] }
+      required: [hostname, source_hostname, commit_id, status, child_status, mode]
+
+    SlicerCommitDeleteResponse:
+      type: object
+      properties:
+        commit_id: { type: string }
+        status: { type: string, enum: [deleted] }
+      required: [commit_id, status]
 
     SlicerDeleteResponse:
       type: object
@@ -841,7 +964,7 @@ paths:
           description: Defaults to reboot unless hypervisor is cloud-hypervisor.
       responses:
         "200":
-          description: Shutdown initiated
+          description: Shutdown completed for a Firecracker shutdown request; otherwise initiated
           content:
             text/plain:
               schema:
@@ -922,8 +1045,8 @@ paths:
       description: |
         Takes a Firecracker snapshot of the VM's memory and disk state, then
         shuts down the underlying VM process. Memory is released. Pair with
-        `/restore` to bring the VM back up. Supported on Slicer-for-Mac,
-        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
+        `/restore` to bring the VM back up. Supported for persistent
+        Firecracker VMs in Slicer and Slicer for Mac.
       security:
         - BearerAuth: []
       parameters:
@@ -958,8 +1081,8 @@ paths:
       summary: Restore a VM from its snapshot
       description: |
         Restores a previously-suspended VM from its Firecracker snapshot.
-        Memory and disk state come back intact. Supported on Slicer-for-Mac,
-        and on Linux when the Slicer daemon is using the Firecracker hypervisor.
+        Memory and disk state come back intact. Supported for persistent
+        Firecracker VMs in Slicer and Slicer for Mac.
       security:
         - BearerAuth: []
       parameters:
@@ -1022,6 +1145,202 @@ paths:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         "500":
           description: Internal error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /vm/{hostname}:
+    get:
+      summary: Describe a VM
+      description: Returns VM lineage plus host-group, override, and effective network policy.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: hostname
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: VM description
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SlicerVMDescription' }
+        "404":
+          description: VM not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /vm/{hostname}/commit:
+    post:
+      summary: Commit a stopped persistent VM disk
+      description: Creates an immutable disk parent for Firecracker cold forks.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: hostname
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SlicerCommitRequest' }
+      responses:
+        "200":
+          description: VM committed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SlicerCommitResponse' }
+        "400":
+          description: VM or storage is not eligible for a cold commit
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Persistent VM not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "409":
+          description: VM is running, backing is missing, or cache key is in use
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /vm/commits:
+    get:
+      summary: List committed VM parents
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: query
+          name: tag
+          description: Repeat to require every supplied tag.
+          schema:
+            type: array
+            items: { type: string }
+          style: form
+          explode: true
+        - in: query
+          name: cache_key
+          schema: { type: string }
+        - in: query
+          name: source
+          schema: { type: string }
+        - in: query
+          name: mode
+          schema: { type: string, enum: [disk] }
+      responses:
+        "200":
+          description: Matching commits, newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/SlicerCommitInfo' }
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /vm/commits/{commit_id}/fork:
+    post:
+      summary: Fork a committed VM disk
+      description: Firecracker-only. Waits for the child agent to finalise a unique guest identity.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: commit_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: wait
+          schema: { type: string, enum: [agent], default: agent }
+        - in: query
+          name: timeout
+          schema: { type: string, default: 30s }
+          description: |
+            Maximum time to wait for agent readiness. On expiry Slicer returns
+            408 and rolls back the child. If the VM process cannot be confirmed
+            stopped, its failed state is left intact for inspection.
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SlicerForkRequest' }
+      responses:
+        "200":
+          description: Child forked and ready
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SlicerForkResponse' }
+        "400":
+          description: Invalid network policy, wait mode, or unsupported host group
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Commit not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "409":
+          description: Child already exists or commit backing is missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "408":
+          description: Agent readiness timed out; child rollback was attempted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "502":
+          description: Guest agent readiness or identity finalisation failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "500":
+          description: Internal or launch error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /vm/commits/{commit_id}:
+    delete:
+      summary: Delete an unused committed VM parent
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: commit_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Commit deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SlicerCommitDeleteResponse' }
+        "404":
+          description: Commit not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "409":
+          description: Persistent source or child VMs still use the commit
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "500":
+          description: Internal or storage cleanup error
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/docs/platform/cold-fork.md
+++ b/docs/platform/cold-fork.md
@@ -1,0 +1,226 @@
+# Build once, fork many
+
+Cold forking starts new microVMs from the disk state of a stopped, persistent VM.
+
+Use it when the VM needs an expensive setup step before each job: installing a compiler, downloading dependencies, pulling container images, or preparing an agent. Set up one builder, commit its disk, then fork as many clean children as you need.
+
+Only disk state is committed. Each child boots normally with its own hostname, machine ID, and network identity.
+
+## Requirements
+
+Cold fork currently requires:
+
+* Firecracker
+* `image`, `devmapper`, or `zfs` storage
+* Bridge or isolated networking
+* A stopped, persistent source VM
+
+Network overrides on `slicer vm fork`, including `--allow`, `--no-allow`, and `--drop`, require isolated networking. Cold forking itself also works with bridge networking, but the child inherits the host group's network policy unchanged.
+
+Forked children are persistent. Delete them explicitly when the job is complete.
+
+## Create an empty host group
+
+This example uses the min image for the fastest boot, image storage for the simplest setup, and isolated networking so the fork can have its egress removed:
+
+```bash
+slicer new runners \
+  --count 0 \
+  --min \
+  --storage image \
+  --net isolated \
+  > slicer.yaml
+```
+
+Start Slicer:
+
+```bash
+sudo -E slicer up slicer.yaml
+```
+
+The generated isolated host group allows egress by default. The builder can download packages and dependencies before its disk is committed.
+
+## Prepare the builder
+
+In another terminal, create a persistent VM:
+
+```bash
+BUILDER=$(slicer vm add runners \
+  --persistent \
+  --tag purpose=cold-fork-builder \
+  --wait \
+  --timeout 10m \
+  --json | jq -r '.hostname')
+
+echo "$BUILDER"
+```
+
+The response contains the allocated hostname. Install and prepare everything that should be present in each child. For example:
+
+```bash
+slicer vm exec "$BUILDER" -- \
+  "sudo arkade system install go"
+
+slicer vm exec "$BUILDER" -- \
+  "git clone https://github.com/alexellis/arkade \
+     /home/ubuntu/arkade && \
+   cd /home/ubuntu/arkade && \
+   /usr/local/go/bin/go build -mod=vendor -o ./arkade"
+```
+
+Do not store reusable credentials in the builder. Every fork inherits its disk.
+
+## Commit the disk
+
+Shut down the builder, then commit it:
+
+```bash
+slicer vm shutdown "$BUILDER"
+
+# The Firecracker shutdown request returns after the VM process has stopped.
+
+COMMIT=$(slicer vm commit "$BUILDER" \
+  --tag arkade \
+  --label toolchain=go \
+  --cache-key arkade-go-v1 \
+  --quiet)
+echo "$COMMIT"
+```
+
+The commit ID identifies an immutable disk parent, for example:
+
+```text
+cmt-runnersx1-a1b2c3d4e5f6a7b8
+```
+
+The source VM remains stopped. A committed source cannot be committed again with different metadata; create another persistent builder when you need a different base.
+
+## Fork a child
+
+To inherit the host group's existing network policy:
+
+```bash
+RUNNER=$(slicer vm fork "$COMMIT" --tag role=runner --quiet)
+```
+
+For a child with no egress, clear the inherited allow list and drop everything else:
+
+```bash
+JOB=arkade-run-$(cat /proc/sys/kernel/random/uuid)
+RUNNER=$(slicer vm fork "$COMMIT" \
+  --tag role=runner \
+  --tag "job=$JOB" \
+  --no-allow \
+  --drop 0.0.0.0/0 \
+  --quiet)
+
+echo "$RUNNER"
+```
+
+`--drop 0.0.0.0/0` on its own is not enough when the host group has the default `--allow 0.0.0.0/0` rule. The allow rule takes precedence, so use `--no-allow` to clear it.
+
+The DROP is enforced on the Slicer host, outside the guest. A root process inside the VM cannot remove it with `iptables`, ignore it by opening a raw socket, or bypass it by unsetting a proxy variable.
+
+The fork command returns after `slicer-agent` has finalised the child's identity. If the client disconnects while waiting, the daemon continues the fork. Recover the allocated hostname through the unique job tag, then describe it:
+
+```bash
+RUNNER=$(slicer vm list --json | jq -r --arg tag "job=$JOB" \
+  '.[] | select((.tags // []) | index($tag)) | .hostname' | head -n1)
+slicer vm describe "$RUNNER"
+```
+
+## Use and delete the child
+
+The child inherits the compiler, source tree, vendored dependencies, and Go build cache from the builder. Change one line and rebuild:
+
+```bash
+slicer vm exec "$RUNNER" -- \
+  "cd /home/ubuntu/arkade && \
+   sed -i \
+     's/boot Linux microVMs instantly/boot Linux microVMs quickly/' \
+     pkg/thanks.go && \
+   /usr/local/go/bin/go build -mod=vendor -o ./arkade"
+```
+
+Delete the child when the job is complete:
+
+```bash
+slicer vm delete "$RUNNER"
+```
+
+The committed parent remains available for another fork.
+
+## Reuse the builder step
+
+A cache key lets an API-driven workflow skip the whole builder step on its next run. It is similar to a Docker build cache, but Slicer caches the complete committed disk rather than individual layers.
+
+Look up the key before launching a builder:
+
+```bash
+KEY=arkade-go-v1
+COMMIT=$(slicer vm commit list \
+  --cache-key "$KEY" \
+  --json | jq -r '.[0].commit_id // empty')
+
+if [ -z "$COMMIT" ]; then
+  BUILDER=$(slicer vm add runners \
+    --persistent \
+    --tag purpose=cold-fork-builder \
+    --wait \
+    --json | jq -r '.hostname')
+
+  # Run the preparation commands from above.
+  slicer vm shutdown "$BUILDER"
+  COMMIT=$(slicer vm commit "$BUILDER" \
+    --cache-key "$KEY" \
+    --quiet)
+fi
+
+RUNNER=$(slicer vm fork "$COMMIT" --tag role=runner --quiet)
+```
+
+The caller owns the cache key. Include the inputs which make the builder result reusable, such as the toolchain version, dependency lock-file digest, or setup-script version. Change the key to invalidate the cached result.
+
+The same lookup is available through `GET /vm/commits?cache_key=...`, `ListCommits()` in the [Go SDK](/platform/go-sdk/), and `client.commits.list()` in the [TypeScript SDK](/platform/typescript-sdk/).
+
+## Organise committed parents
+
+Add tags, labels, or a deterministic cache key when the calling application needs to find a committed parent later. Commit metadata is immutable, so set it on the initial `slicer vm commit` command, as shown above.
+
+List all committed parents, or filter the list:
+
+```bash
+slicer vm commit list
+slicer vm commit list --tag arkade
+slicer vm commit list --cache-key arkade-go-v1
+slicer vm commit list --source "$BUILDER"
+```
+
+Delete a committed parent when neither its source VM nor any forked child uses it:
+
+```bash
+slicer vm commit delete "$COMMIT"
+```
+
+## Cold fork, suspend, and restore
+
+Cold fork and suspend solve different problems:
+
+* `slicer vm commit` records disk state from a stopped VM. Each fork is a new VM which boots from that state.
+* `slicer vm suspend` records memory, disk, and device state. `slicer vm restore` resumes the same VM later.
+
+Persistent Firecracker VMs in Slicer, and VMs in Slicer for Mac, can suspend and restore today. A suspended VM cannot yet be forked into several children.
+
+## Cold fork or a custom image?
+
+A [custom Slicer image](/platform/custom-images/) is the better fit for a versioned base which needs to be distributed across several hosts. It can be built in CI, pushed to a registry, and referenced from a host group.
+
+Cold fork is a leaner local loop. Prepare a running VM interactively, commit it, then fork locally without building a Dockerfile, pushing and pulling an OCI image, or unpacking it again on the Slicer host.
+
+## See also
+
+* [VM lifecycle](/platform/lifecycle/)
+* [Networking](/reference/networking/)
+* [Storage backends](/storage/overview/)
+* [Build a custom image](/platform/custom-images/)
+* [Go SDK cold forking example](https://github.com/slicervm/sdk/blob/master/examples/cold-fork/main.go)

--- a/docs/platform/go-sdk.md
+++ b/docs/platform/go-sdk.md
@@ -187,11 +187,24 @@ err = client.ResumeVM(ctx, node.Hostname)
 | `ListVMs(ctx)` | List all VMs across host groups |
 | `GetHostGroups(ctx)` | List host groups |
 | `GetHostGroupNodes(ctx, groupName)` | List VMs in a host group |
+| `DescribeVM(ctx, hostname)` | Get configuration, fork lineage, and effective network policy |
 | `PauseVM(ctx, hostname)` | Pause a running VM |
 | `ResumeVM(ctx, hostname)` | Resume a paused VM |
 | `Shutdown(ctx, hostname, request)` | Shutdown or reboot a VM |
 | `GetVMStats(ctx, hostname)` | Get CPU, memory, and disk stats |
 | `GetVMLogs(ctx, hostname, lines)` | Get serial console logs |
+
+### Cold fork operations
+
+| Method | Description |
+|--------|-------------|
+| `CommitVM(ctx, hostname)` | Commit a stopped, persistent VM |
+| `CommitVMWithOptions(ctx, hostname, opts)` | Commit with tags, labels, or a cache key |
+| `ListCommits(ctx, opts)` | List or filter committed parents |
+| `ForkCommittedVM(ctx, commitID)` | Fork a committed parent |
+| `ForkCommittedVMWithOptions(ctx, commitID, opts)` | Fork with tags or an isolated-network override |
+| `committed.Fork(ctx, opts)` | Fork the `SlicerCommittedVM` returned by `CommitVM` |
+| `DeleteCommit(ctx, commitID)` | Delete an unused committed parent |
 
 ### Guest operations
 

--- a/docs/platform/typescript-sdk.md
+++ b/docs/platform/typescript-sdk.md
@@ -57,6 +57,7 @@ The SDK has two layers:
 
 * `client.hostGroups` — list host groups, list VMs within a group.
 * `client.vms` — create, attach, list, and collect stats for VMs across host groups.
+* `client.commits` — list, fork, and delete committed VM parents.
 * `client.secrets` — create, list, update, delete secrets.
 
 **Per-VM operations — on the `VM` handle returned from `client.vms.create()` or `client.vms.get()`.** Everything you do to a single VM is a method on its handle:
@@ -234,7 +235,7 @@ await vm.pause();
 await vm.resume();
 ```
 
-Suspend writes a snapshot to disk (Slicer for Mac; Linux support in progress). `relaunch()` restarts an API-created VM from its existing disk (requires `persistent: true` at creation time):
+Suspend writes a persistent Firecracker VM's snapshot to disk in Slicer or Slicer for Mac. `relaunch()` restarts an API-created VM from its existing disk (requires `persistent: true` at creation time):
 
 ```ts
 await vm.suspend();
@@ -283,6 +284,14 @@ The SDK base64-encodes secret data transparently; pass plaintext.
 | `client.vms.list({ tag?, tagPrefix? })` | List all VMs |
 | `client.vms.stats()` | Per-VM CPU / memory / disk stats |
 
+### Commits
+
+| Method | Description |
+|--------|-------------|
+| `client.commits.list(opts?)` | List or filter committed parents |
+| `client.commits.fork(commitId, opts?)` | Fork with tags or an isolated-network override |
+| `client.commits.delete(commitId)` | Delete an unused committed parent |
+
 ### VM handle — `vm.*`
 
 | Method | Description |
@@ -293,11 +302,20 @@ The SDK base64-encodes secret data transparently; pass plaintext.
 | `vm.waitForAgent(opts?)` | Poll until the agent responds |
 | `vm.waitForUserdata(opts?)` | Poll until userdata completes |
 | `vm.logs()` | Serial console logs |
+| `vm.describe()` | Configuration, fork lineage, and effective network policy |
+| `vm.commit(opts?)` | Commit a stopped, persistent VM and return a `CommittedVM` |
 | `vm.pause() / resume()` | Pause or resume the VM in memory |
-| `vm.suspend() / restore()` | Snapshot to/from disk (Mac) |
+| `vm.suspend() / restore()` | Snapshot a persistent Firecracker VM to/from disk |
 | `vm.shutdown(req?) / relaunch()` | Shut down or relaunch a persistent VM |
 | `vm.delete()` | Delete the VM |
 | `vm.fs.*` | Filesystem operations (below) |
+
+### Committed VM — `committed.*`
+
+| Method | Description |
+|--------|-------------|
+| `committed.fork(opts?)` | Fork and return a `VM` handle |
+| `committed.forkRaw(opts?)` | Fork and return the raw response |
 
 ### VM filesystem — `vm.fs.*`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -619,8 +619,8 @@ Takes a Firecracker snapshot of the VM's memory and disk state, then
 shuts down the underlying VM process. Memory is released. Use
 `/restore` to bring the VM back up from the snapshot.
 
-> Availability: supported on Slicer-for-Mac, and on Linux when the Slicer
-> daemon is using the Firecracker hypervisor.
+> Availability: supported for persistent Firecracker VMs in Slicer and
+> Slicer for Mac.
 
 Response 200: text/plain
 
@@ -633,10 +633,72 @@ HTTP POST
 Restores a previously-suspended VM from its Firecracker snapshot. The
 VM resumes with its memory and disk state intact.
 
-> Availability: supported on Slicer-for-Mac, and on Linux when the Slicer
-> daemon is using the Firecracker hypervisor.
+> Availability: supported for persistent Firecracker VMs in Slicer and
+> Slicer for Mac.
 
 Response 200: text/plain
+
+## Describe a VM
+
+HTTP GET
+
+`/vm/{hostname}`
+
+Returns the VM's configuration, fork lineage, and effective network policy.
+
+Response 200: `SlicerVMDescription`
+
+## Commit a VM
+
+HTTP POST
+
+`/vm/{hostname}/commit`
+
+The VM must be stopped and persistent. The optional JSON body accepts
+`tags` (an array of strings), `labels` (a string map), and `cache_key`.
+
+Response 200: `SlicerCommitResponse`
+
+## List VM commits
+
+HTTP GET
+
+`/vm/commits`
+
+Optional query parameters: repeatable `tag`, `cache_key`, `source`, and
+`mode`.
+
+Response 200: an array of `SlicerCommitInfo`
+
+## Fork a committed VM
+
+HTTP POST
+
+`/vm/commits/{commit_id}/fork`
+
+Fork always waits for the guest agent to finalise the child's identity. The
+optional `timeout` query parameter sets the readiness timeout. The optional
+JSON body accepts `tags` and an isolated-network `network` override with
+`allow` and `drop` arrays. Network overrides require an isolated host group.
+
+The hostname is allocated by Slicer and returned in the response.
+
+If agent readiness exceeds `timeout`, Slicer returns 408 and rolls the child
+back. If it cannot confirm that the VM process stopped, the failed state is
+left intact for inspection. Guest readiness or identity-finalisation failures
+return 502.
+
+Response 200: `SlicerForkResponse`
+
+## Delete a VM commit
+
+HTTP DELETE
+
+`/vm/commits/{commit_id}`
+
+The commit cannot be deleted while a source VM or forked child still uses it.
+
+Response 200: `SlicerCommitDeleteResponse`
 
 ## Relaunch an API-launched VM
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
       - Overview: platform/overview.md
       - Quickstart: platform/quickstart.md
       - VM Lifecycle: platform/lifecycle.md
+      - Build once, fork many: platform/cold-fork.md
       - Go SDK: platform/go-sdk.md
       - TypeScript SDK: platform/typescript-sdk.md
       - Run a task in Slicer: platform/ephemeral-tasks.md


### PR DESCRIPTION
## What changed

- add a complete cold-forking platform guide
- document the Open Builder/Closed Runner workflow
- cover whole-builder cache keys, CLI and SDK automation, and lifecycle
- distinguish bridge-mode forking from isolated-network policy overrides
- document Firecracker, storage, suspend/restore, and Slicer for Mac boundaries
- align the published OpenAPI schema with allocator-led child naming

## Why

Cold forking now has a stable initial workflow and API, but the platform docs
did not explain how to prepare, cache, fork, restrict, or clean up builders and
runners.

## Validation

- `mkdocs build`
- `git diff --check HEAD^ HEAD`

The build completes with the repository's existing navigation, deprecation,
and absolute-link warnings.

Related Slicer PR: https://github.com/openfaasltd/slicer/pull/108
