### PR TITLE
Refine cold fork documentation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -373,7 +373,7 @@ components:
         secrets:
           type: array
           items: { type: string }
-          description: Replaces inherited secret grants. An empty array clears grants and blots inherited secret files.
+          description: Replaces inherited secret grants. An empty array clears grants and removes inherited secret files.
         persistent:
           type: boolean
           default: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -350,7 +350,7 @@ components:
 
     SlicerForkNetworkPolicy:
       type: object
-      description: Isolated-network overrides for the child VM.
+      description: Isolated-network overrides for the forked VM.
       properties:
         allow:
           type: array
@@ -365,6 +365,34 @@ components:
         tags:
           type: array
           items: { type: string }
+          description: Tags to append, or to replace when tag_mode is replace.
+        tag_mode:
+          type: string
+          enum: [append, replace]
+          default: append
+        secrets:
+          type: array
+          items: { type: string }
+          description: Replaces inherited secret grants. An empty array clears grants and blots inherited secret files.
+        persistent:
+          type: boolean
+          default: true
+          description: Set false to discard cloned storage when the VM stops or is deleted.
+        fixups:
+          type: array
+          items:
+            type: string
+            enum: [all, none, hostname, machine-id, ssh-host-keys]
+          description: Omit for all correctness fix-ups. Pass an empty array, or none by itself, to disable them; all and none must be used alone.
+        vcpu:
+          type: integer
+          minimum: 1
+          description: vCPU count, up to the source host-group limit.
+        ram_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+          description: RAM in bytes, up to the source host-group limit.
         network:
           $ref: '#/components/schemas/SlicerForkNetworkPolicy'
 
@@ -376,9 +404,10 @@ components:
         commit_id: { type: string }
         status: { type: string, enum: [forked] }
         parent_status: { type: string, enum: [unchanged] }
-        child_status: { type: string, enum: [running] }
+        child_status: { type: string, enum: [starting, running] }
         mode: { type: string, enum: [disk] }
-      required: [hostname, source_hostname, commit_id, status, child_status, mode]
+        persistent: { type: boolean }
+      required: [hostname, source_hostname, commit_id, status, child_status, mode, persistent]
 
     SlicerCommitDeleteResponse:
       type: object
@@ -1254,7 +1283,7 @@ paths:
   /vm/commits/{commit_id}/fork:
     post:
       summary: Fork a committed VM disk
-      description: Firecracker-only. Waits for the child agent to finalise a unique guest identity.
+      description: Firecracker-only. Waits for agent readiness and guest finalisation by default. With wait=none, acknowledges launch while finalisation continues asynchronously.
       security:
         - BearerAuth: []
       parameters:
@@ -1264,21 +1293,22 @@ paths:
           schema: { type: string }
         - in: query
           name: wait
-          schema: { type: string, enum: [agent], default: agent }
+          schema: { type: string, enum: [agent, none], default: agent }
         - in: query
           name: timeout
           schema: { type: string, default: 30s }
           description: |
-            Maximum time to wait for agent readiness. On expiry Slicer returns
-            408 and rolls back the child. If the VM process cannot be confirmed
-            stopped, its failed state is left intact for inspection.
+            Maximum time for agent readiness and guest finalisation. When
+            waiting, expiry returns 408 and rolls back the forked VM. If the VM
+            process cannot be confirmed stopped, its failed state is left
+            intact for inspection.
       requestBody:
         content:
           application/json:
             schema: { $ref: '#/components/schemas/SlicerForkRequest' }
       responses:
         "200":
-          description: Child forked and ready
+          description: VM forked; child_status is running when waited or starting for launch acknowledgement
           content:
             application/json:
               schema: { $ref: '#/components/schemas/SlicerForkResponse' }
@@ -1293,12 +1323,12 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         "409":
-          description: Child already exists or commit backing is missing
+          description: Allocated VM state already exists or commit backing is missing
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         "408":
-          description: Agent readiness timed out; child rollback was attempted
+          description: Agent readiness or finalisation timed out; VM rollback was attempted
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -1335,7 +1365,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         "409":
-          description: Persistent source or child VMs still use the commit
+          description: Persistent source or forked VMs still use the commit
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/docs/platform/cold-fork.md
+++ b/docs/platform/cold-fork.md
@@ -2,9 +2,9 @@
 
 Cold forking starts new microVMs from the disk state of a stopped, persistent VM.
 
-Use it when the VM needs an expensive setup step before each job: installing a compiler, downloading dependencies, pulling container images, or preparing an agent. Set up one builder, commit its disk, then fork as many clean children as you need.
+Use it when the VM needs an expensive setup step before each job: installing a compiler, downloading dependencies, pulling container images, or preparing an agent. Set up one builder, commit its disk, then fork as many clean VMs as you need.
 
-Only disk state is committed. Each child boots normally with its own hostname, machine ID, and network identity.
+Only disk state is committed. Each forked VM boots normally with its own hostname, machine ID, and network identity by default.
 
 ## Requirements
 
@@ -15,9 +15,9 @@ Cold fork currently requires:
 * Bridge or isolated networking
 * A stopped, persistent source VM
 
-Network overrides on `slicer vm fork`, including `--allow`, `--no-allow`, and `--drop`, require isolated networking. Cold forking itself also works with bridge networking, but the child inherits the host group's network policy unchanged.
+Network overrides on `slicer vm fork`, including `--allow`, `--no-allow`, and `--drop`, require isolated networking. Cold forking itself also works with bridge networking, but the forked VM inherits the host group's network policy unchanged.
 
-Forked children are persistent. Delete them explicitly when the job is complete.
+The CLI creates persistent forked VMs by default. Pass `--rm` for an ephemeral fork whose cloned storage is discarded when the VM stops or is deleted.
 
 ## Create an empty host group
 
@@ -55,7 +55,7 @@ BUILDER=$(slicer vm add runners \
 echo "$BUILDER"
 ```
 
-The response contains the allocated hostname. Install and prepare everything that should be present in each child. For example:
+The response contains the allocated hostname. Install and prepare everything that should be present in each forked VM. For example:
 
 ```bash
 slicer vm exec "$BUILDER" -- \
@@ -95,19 +95,20 @@ cmt-runnersx1-a1b2c3d4e5f6a7b8
 
 The source VM remains stopped. A committed source cannot be committed again with different metadata; create another persistent builder when you need a different base.
 
-## Fork a child
+## Fork a VM
 
 To inherit the host group's existing network policy:
 
 ```bash
-RUNNER=$(slicer vm fork "$COMMIT" --tag role=runner --quiet)
+RUNNER=$(slicer vm fork "$COMMIT" --wait --tag role=runner --quiet)
 ```
 
-For a child with no egress, clear the inherited allow list and drop everything else:
+For a forked VM with no egress, clear the inherited allow list and drop everything else:
 
 ```bash
 JOB=arkade-run-$(cat /proc/sys/kernel/random/uuid)
 RUNNER=$(slicer vm fork "$COMMIT" \
+  --wait \
   --tag role=runner \
   --tag "job=$JOB" \
   --no-allow \
@@ -121,7 +122,7 @@ echo "$RUNNER"
 
 The DROP is enforced on the Slicer host, outside the guest. A root process inside the VM cannot remove it with `iptables`, ignore it by opening a raw socket, or bypass it by unsetting a proxy variable.
 
-The fork command returns after `slicer-agent` has finalised the child's identity. If the client disconnects while waiting, the daemon continues the fork. Recover the allocated hostname through the unique job tag, then describe it:
+The CLI returns as soon as the VM starts unless you pass `--wait`. The examples use `--wait` so `slicer-agent` has finalised the VM's identity before the next command runs. If the client disconnects, the daemon continues the fork. Recover the allocated hostname through the unique job tag, then describe it:
 
 ```bash
 RUNNER=$(slicer vm list --json | jq -r --arg tag "job=$JOB" \
@@ -129,9 +130,40 @@ RUNNER=$(slicer vm list --json | jq -r --arg tag "job=$JOB" \
 slicer vm describe "$RUNNER"
 ```
 
-## Use and delete the child
+## Control fork behaviour
 
-The child inherits the compiler, source tree, vendored dependencies, and Go build cache from the builder. Change one line and rebuild:
+By default, Slicer fixes the hostname, machine ID, and SSH host keys. SSH host-key work is skipped when `sshd` is not installed; otherwise Slicer follows the image's configured `HostKey` paths.
+
+For maximum throughput when duplicated guest identity is acceptable, skip every fix-up and do not wait:
+
+```bash
+RUNNER=$(slicer vm fork "$COMMIT" \
+  --no-fixups \
+  --rm \
+  --quiet)
+```
+
+You can also select individual fix-ups, scale CPU and RAM down within the source host group's limits, replace inherited tags, and replace or clear inherited secret grants:
+
+```bash
+RUNNER=$(slicer vm fork "$COMMIT" \
+  --wait \
+  --fixup hostname \
+  --fixup machine-id \
+  --cpu 1 \
+  --ram-mb 512 \
+  --replace-tags \
+  --tag role=runner \
+  --no-secrets \
+  --rm \
+  --quiet)
+```
+
+`--no-secrets` also removes inherited secret files during finalisation. Omitting tag, secret, network, CPU, or RAM options inherits the committed VM's launch configuration. Userdata is disk state and is not run again on a fork.
+
+## Use and delete the VM
+
+The forked VM inherits the compiler, source tree, vendored dependencies, and Go build cache from the builder. Change one line and rebuild:
 
 ```bash
 slicer vm exec "$RUNNER" -- \
@@ -142,7 +174,7 @@ slicer vm exec "$RUNNER" -- \
    /usr/local/go/bin/go build -mod=vendor -o ./arkade"
 ```
 
-Delete the child when the job is complete:
+Delete the VM when the job is complete:
 
 ```bash
 slicer vm delete "$RUNNER"
@@ -176,7 +208,7 @@ if [ -z "$COMMIT" ]; then
     --quiet)
 fi
 
-RUNNER=$(slicer vm fork "$COMMIT" --tag role=runner --quiet)
+RUNNER=$(slicer vm fork "$COMMIT" --wait --tag role=runner --quiet)
 ```
 
 The caller owns the cache key. Include the inputs which make the builder result reusable, such as the toolchain version, dependency lock-file digest, or setup-script version. Change the key to invalidate the cached result.
@@ -196,7 +228,7 @@ slicer vm commit list --cache-key arkade-go-v1
 slicer vm commit list --source "$BUILDER"
 ```
 
-Delete a committed parent when neither its source VM nor any forked child uses it:
+Delete a committed parent when neither its source VM nor any forked VM uses it:
 
 ```bash
 slicer vm commit delete "$COMMIT"
@@ -209,7 +241,7 @@ Cold fork and suspend solve different problems:
 * `slicer vm commit` records disk state from a stopped VM. Each fork is a new VM which boots from that state.
 * `slicer vm suspend` records memory, disk, and device state. `slicer vm restore` resumes the same VM later.
 
-Persistent Firecracker VMs in Slicer, and VMs in Slicer for Mac, can suspend and restore today. A suspended VM cannot yet be forked into several children.
+Persistent Firecracker VMs in Slicer, and VMs in Slicer for Mac, can suspend and restore today. A suspended VM cannot yet be forked into several VMs.
 
 ## Cold fork or a custom image?
 

--- a/docs/platform/go-sdk.md
+++ b/docs/platform/go-sdk.md
@@ -201,10 +201,11 @@ err = client.ResumeVM(ctx, node.Hostname)
 | `CommitVM(ctx, hostname)` | Commit a stopped, persistent VM |
 | `CommitVMWithOptions(ctx, hostname, opts)` | Commit with tags, labels, or a cache key |
 | `ListCommits(ctx, opts)` | List or filter committed parents |
-| `ForkCommittedVM(ctx, commitID)` | Fork a committed parent |
-| `ForkCommittedVMWithOptions(ctx, commitID, opts)` | Fork with tags or an isolated-network override |
-| `committed.Fork(ctx, opts)` | Fork the `SlicerCommittedVM` returned by `CommitVM` |
+| `ForkCommittedVM(ctx, commitID, options...)` | Fork with defaults or functional options |
+| `committed.Fork(ctx, options...)` | Fork the `SlicerCommittedVM` returned by `CommitVM` |
 | `DeleteCommit(ctx, commitID)` | Delete an unused committed parent |
+
+Fork options include `WithVCPU`, `WithRAMBytes`, `WithTags`, `WithReplaceTags`, `WithSecrets`, `WithNetwork`, `WithPersistent`, `WithEphemeral`, `WithFixups`, `WithWait`, and `WithTimeout`. Omitting options keeps the correctness-first persistent default; `WithFixups()` disables guest identity fix-ups, and `WithWait(SlicerForkWaitNone)` returns after launch acknowledgement.
 
 ### Guest operations
 

--- a/docs/platform/typescript-sdk.md
+++ b/docs/platform/typescript-sdk.md
@@ -289,7 +289,7 @@ The SDK base64-encodes secret data transparently; pass plaintext.
 | Method | Description |
 |--------|-------------|
 | `client.commits.list(opts?)` | List or filter committed parents |
-| `client.commits.fork(commitId, opts?)` | Fork with tags or an isolated-network override |
+| `client.commits.fork(commitId, opts?)` | Fork with lifecycle, resources, fix-ups, metadata, secrets, wait, or network overrides |
 | `client.commits.delete(commitId)` | Delete an unused committed parent |
 
 ### VM handle — `vm.*`
@@ -314,8 +314,10 @@ The SDK base64-encodes secret data transparently; pass plaintext.
 
 | Method | Description |
 |--------|-------------|
-| `committed.fork(opts?)` | Fork and return a `VM` handle |
+| `committed.fork(opts?)` | Fork with optional overrides and return a `VM` handle |
 | `committed.forkRaw(opts?)` | Fork and return the raw response |
+
+`VMForkOptions` supports `wait`, `waitTimeoutSec`, `persistent`, `vcpu`, `ramBytes`, `fixups`, `tags`, `tagMode`, `secrets`, and `network`. Forks wait for agent readiness and guest finalisation by default. Use `wait: 'none'` for launch acknowledgement only, `persistent: false` for ephemeral storage, or `fixups: []` when throughput matters more than unique guest identity.
 
 ### VM filesystem — `vm.fs.*`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -676,17 +676,30 @@ HTTP POST
 
 `/vm/commits/{commit_id}/fork`
 
-Fork always waits for the guest agent to finalise the child's identity. The
-optional `timeout` query parameter sets the readiness timeout. The optional
-JSON body accepts `tags` and an isolated-network `network` override with
-`allow` and `drop` arrays. Network overrides require an isolated host group.
+Fork waits for guest-agent readiness and finalisation by default. Set
+`wait=none` to acknowledge launch without waiting; if asynchronous
+finalisation later fails, the daemon removes the forked VM. The optional
+`timeout` query parameter sets the readiness and finalisation timeout.
+
+The optional JSON body accepts:
+
+* `vcpu` and `ram_bytes` to scale down within the source host group's limits.
+* `persistent` (default `true`); set it to `false` for an ephemeral fork.
+* `fixups`: `hostname`, `machine-id`, and `ssh-host-keys`. Omit the field for
+  all correctness fix-ups, or pass an empty array to disable them. The special
+  values `all` and `none` are also accepted when used alone.
+* `tags` with `tag_mode` set to `append` (default) or `replace`.
+* `secrets` to replace inherited grants; an empty array clears the grants and
+  removes their files during finalisation.
+* An isolated-network `network` override with `allow` and `drop` arrays.
+
+Network overrides require an isolated host group.
 
 The hostname is allocated by Slicer and returned in the response.
 
-If agent readiness exceeds `timeout`, Slicer returns 408 and rolls the child
-back. If it cannot confirm that the VM process stopped, the failed state is
-left intact for inspection. Guest readiness or identity-finalisation failures
-return 502.
+When waiting, a readiness timeout returns 408 and rolls the forked VM back. If
+Slicer cannot confirm that the VM process stopped, it leaves the failed state
+intact for inspection. Guest readiness or finalisation failures return 502.
 
 Response 200: `SlicerForkResponse`
 
@@ -696,7 +709,7 @@ HTTP DELETE
 
 `/vm/commits/{commit_id}`
 
-The commit cannot be deleted while a source VM or forked child still uses it.
+The commit cannot be deleted while a source VM or forked VM still uses it.
 
 Response 200: `SlicerCommitDeleteResponse`
 


### PR DESCRIPTION
## What changed

- document persistent and ephemeral forks, readiness waits, resource scale-down, identity fix-ups, tags, secrets, and network overrides
- update the Go and TypeScript SDK references for the released fork APIs
- extend the REST and OpenAPI references with the final request and response fields
- replace “child” terminology with “forked VM” throughout the workflow

## Why

The initial cold-fork documentation is already on `master`. These refinements distinguish the correctness-first defaults from the no-wait, no-fix-up throughput path, and align the examples and references with the released SDK interfaces.

## Validation

- `mkdocs build`
- parsed `docs/openapi.yaml` with PyYAML
- `git diff --check`

`mkdocs build --strict` reaches the site build but aborts on the repository's existing deprecated `materialx.emoji` configuration warning.
