### PR TITLE
Run Slicer from the default Linux directory

### DIFF
--- a/docs/getting-started/daemon.md
+++ b/docs/getting-started/daemon.md
@@ -16,12 +16,12 @@ You can run one or many Slicer daemons in this way, just make sure the host grou
 Let's say you wanted to create a service for a hostgroup named "vm":
 
 ```bash
-mkdir -p ~/vm/
-cd ~/vm/
-slicer new vm > ./slicer.yaml
+mkdir -p ~/slicer
+cd ~/slicer
+slicer new vm --socket ./slicer.sock > ./slicer.yaml
 ```
 
-To listen on a UNIX port instead, use `slicer new vm --api-auth=false --api-bind ./slicer.sock > ./slicer.yaml`.
+To listen on TCP instead, use `slicer new vm --api-bind 127.0.0.1 --api-port 8080 > ./slicer.yaml`.
 
 Install and start the service:
 
@@ -62,16 +62,11 @@ export USER=alex
 echo "$USER ALL=(ALL) NOPASSWD: /usr/local/bin/slicer" | sudo tee /etc/sudoers.d/$USER-slicer
 ```
 
-Assuming you went for the UNIX socket option, you could run i.e.
+The CLI looks for an explicit `--url/--socket` flag or `SLICER_URL` environment variable
+first. Without either, it tries `~/slicer/slicer.sock`, then falls back to
+`http://127.0.0.1:8080`.
 
-```bash
-sudo slicer --url ~/vm/slicer.sock vm list
-HOSTNAME                  IP              RAM          CPUS     STATUS     CREATED              TAGS                
---------                  --              ---          ----     ------     -------              -----               
-vm-1                      192.168.137.2   4GiB         2        Running    2026-02-27 16:30:53      
-```
-
-For the TCP option (with the default port of 8080), you'd run:
+To list VMs run:
 
 ```bash
 sudo slicer vm list

--- a/docs/getting-started/walkthrough.md
+++ b/docs/getting-started/walkthrough.md
@@ -9,7 +9,9 @@ Slicer is a long lived process that can be run in the foreground or as a daemon 
 Config files can be copy and pasted from the docs, or you can generate one from a template by running the below, where `vm` is the name of the hostgroup.
 
 ```bash
-slicer new vm > vm-image.yaml
+mkdir -p ~/slicer
+cd ~/slicer
+slicer new vm > slicer.yaml
 ```
 
 The default configuration uses a Linux bridge for networking, a disk image for storage, and the Firecracker hypervisor.
@@ -53,7 +55,8 @@ The `storage: image` setting means a disk image will be cloned from the root fil
 Now, open a new terminal window, or ideally launch `tmux` so you can leave the binary running in the background.
 
 ```bash
-sudo slicer up ./vm-image.yaml
+cd ~/slicer
+sudo slicer up ./slicer.yaml
 ```
 
 Having customised the `github_user` to your own username, your SSH keys will have been fetched from your profile, and preinstalled into the VM.


### PR DESCRIPTION
## Description

Updates the Linux walkthrough and daemon guide to run Slicer from `~/slicer`.

The walkthrough retains the default loopback TCP endpoint, while the systemd daemon setup places its API socket at `~/slicer/slicer.sock`. The daemon guide also documents the CLI endpoint discovery order and retains loopback TCP as an alternative.

## Motivation and Context

The Slicer CLI now discovers `~/slicer/slicer.sock` by default, including when invoked through `sudo`. Using `~/slicer` as the standard working directory aligns the documentation with this behavior while preserving the walkthrough default of listening on loopback TCP.

- [ ] I have raised an issue to propose this change ([required](https://github.com/slicervm/docs.slicervm.com/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

The updated commands were verified.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`