### PR TITLE
Fix dns_servers indentation in mac proxy setup snippet

### DIFF
--- a/docs/proxy/mac.md
+++ b/docs/proxy/mac.md
@@ -29,10 +29,10 @@ The below is a partial snippet, to show the changes you need to make.
       sleep_action: prevent
       share_home: ""
       userdata: ""
++     dns_servers: ["127.0.0.1", "127.0.0.1"]
       network:
         mode: nat
         gateway: 192.168.64.1/24
-+       dns_servers: ["127.0.0.1", "127.0.0.1"]
         # Default is no managed PF filtering. To force sbox traffic through a
         # host proxy, opt in with:
 -       # allow:


### PR DESCRIPTION
## Summary
- `docs/proxy/mac.md`'s sbox host-group diff nests `dns_servers` inside the `network:` block
- `slicer-mac`'s (and Linux `slicer`'s) config schema defines `dns_servers` as a host-group-level field — a sibling of `network:`, never a child of it — and both platforms' `new` generators emit it that way
- YAML unmarshalling silently drops unknown fields, so following this snippet exactly leaves the guest on its default DNS servers (8.8.8.8/1.1.1.1) instead of the intended `127.0.0.1` redirect — and those default DNS queries then get dropped outright by the `drop: [0.0.0.0/0]` rule this same snippet adds, since only ports 3128/3129 are allowed
- Confirmed via a customer's proxy setup: their config, copied from this exact snippet, had `dns_servers` silently ignored for this reason

## Fix
Move `dns_servers` back out to the host-group level, matching the repo's own reference `slicer-mac.yaml` (which already has it correctly placed, with a comment showing the right value for the transparent-proxy case).

## Test plan
- [x] Confirmed against `slicer-mac/pkg/config.go`: `DNSServers` is a `slicerHostGroup` field, not part of `slicerNetworkConfig`
- [x] Confirmed against `slicer/pkg/config.go`: same convention on Linux (`HostGroup.DNSServers` sibling of `HostGroup.Network`)
- [x] Confirmed both `slicer-mac new` and `slicer new` generator templates emit `dns_servers` at the host-group level
- [x] Diffed against the repo's own `slicer-mac/slicer-mac.yaml` reference config, which has it right