### PR TITLE
Document macOS Application Firewall block-all as a proxy gotcha

### DIFF
--- a/docs/proxy/mac.md
+++ b/docs/proxy/mac.md
@@ -7,6 +7,18 @@ On a macOS host, there are two host groups for Slicer.
 
 Just like on Linux, "slicer proxy" is an additional daemon that runs alongside Slicer.
 
+## Before you start: check the macOS Application Firewall
+
+If **System Settings → Network → Firewall → Options → Block all incoming connections** is turned on, the proxy still completes the TCP handshake, but the connection dies before any data reaches it. Requests from `127.0.0.1` work fine (the firewall doesn't filter loopback), but anything else — the NAT gateway IP, a guest VM — fails silently with nothing in the proxy's own logs, since the firewall intercepts below the application layer. This is easy to miss because it isn't third-party software; it ships with macOS, and security-conscious users often have it turned on deliberately.
+
+Check it with:
+
+```bash
+/usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
+```
+
+If it reports `enabled`, either turn it off, or explicitly allow the `slicer` binary under **Firewall → Options**, then restart the proxy.
+
 You will be responsible for starting and configuring the proxy and we recommend running it inside the same working folder as your Slicer daemon in the `~/slicer-mac` folder.
 
 First, edit `slicer-mac.yaml`, and make sure the CA and networking options are uncommented in the `sbox` host group section.


### PR DESCRIPTION
## Summary
Diagnosed a customer's `slicer proxy` connections dying silently on their bridge/gateway address while loopback worked fine, no proxy log output for the failing requests, and a packet capture showing the TCP handshake complete with zero response bytes ever written.

Root cause: macOS's built-in Application Firewall set to "Block all incoming connections." It exempts loopback but intercepts everything else below the application layer — matches every symptom observed exactly, and looks identical to a proxy-side hang without instrumentation to prove otherwise.

This is stock macOS behavior, not third-party software, so it's likely to bite other security-conscious users (VPN/firewall-aware folks are exactly the demographic running a local proxy setup like this) the same way. Documenting the one-line check so the next person doesn't need a multi-hour packet-capture investigation to find it.

## Change
Adds a "Before you start" section near the top of `docs/proxy/mac.md` with the check command (`socketfilterfw --getblockall`, verified against a real Mac) and the fix.