### PR TITLE
Mark disk_image deprecated in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -224,6 +224,8 @@ components:
           type: boolean
         disk_image:
           type: string
+          deprecated: true
+          description: Rejected via the API; the disk image is always <hostname>.img.
         import_user:
           type: string
         ssh_keys:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -226,6 +226,8 @@ components:
           type: boolean
         disk_image:
           type: string
+          deprecated: true
+          description: Rejected via the API; the disk image is always <hostname>.img.
         import_user:
           type: string
         ssh_keys:


### PR DESCRIPTION
The VM launch API now rejects any non-empty `disk_image` with 400; the disk image is always `<hostname>.img` in the working directory (see openfaasltd/slicer#133).

Both tracked spec copies still advertised the field as an optional parameter. This marks it `deprecated` with a note in each:

- `openapi.yaml` (root — the 'Download openapi.yaml' link target)
- `docs/openapi.yaml` (mkdocs source, served at `/openapi.yaml`)

No markdown doc references the field, so no prose changes were needed.