### PR TITLE
Clarify cold-fork is disk-only in the OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1206,7 +1206,12 @@ paths:
   /vm/{hostname}/commit:
     post:
       summary: Commit a stopped persistent VM disk
-      description: Creates an immutable disk parent for Firecracker cold forks.
+      description: >-
+        Creates an immutable disk parent for Firecracker cold forks. A cold
+        fork snapshots the VM's **disk only** — never CPU or RAM state — so
+        the source VM must be **shut down first** (a running VM returns 409).
+        Anything a fork should inherit must be written to a real on-disk path,
+        not tmpfs paths like /tmp which are cleared on shutdown.
       security:
         - BearerAuth: []
       parameters:
@@ -1285,7 +1290,14 @@ paths:
   /vm/commits/{commit_id}/fork:
     post:
       summary: Fork a committed VM disk
-      description: Firecracker-only. Waits for agent readiness and guest finalisation by default. With wait=none, acknowledges launch while finalisation continues asynchronously.
+      description: >-
+        Firecracker-only. Boots a new VM from a committed disk parent. The
+        child inherits the parent's **disk state only** — it is a fresh boot,
+        not a resumed memory/CPU snapshot. Set an environment up once, commit
+        it, then fork it many times to branch from an identical starting
+        point. Waits for agent readiness and guest finalisation by default;
+        with wait=none, acknowledges launch while finalisation continues
+        asynchronously.
       security:
         - BearerAuth: []
       parameters:


### PR DESCRIPTION
The commit and fork endpoint descriptions did not state the cold-fork semantics that trip people up. Spell out that a cold fork snapshots the **disk only** (never CPU/RAM), the source VM must be **shut down first**, and only on-disk state carries to a child — so anything a fork should inherit must be written to a real path, not tmpfs like /tmp.

The prose page `docs/platform/cold-fork.md` already says this; this brings the OpenAPI reference in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)